### PR TITLE
Make CI succeed again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   build-deploy:
     env:
       BASE_VERSION: 1.5.99999
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v1
     - name: Build and Package

--- a/DeviceTests/DeviceTests.iOS/Main.cs
+++ b/DeviceTests/DeviceTests.iOS/Main.cs
@@ -6,7 +6,9 @@ namespace DeviceTests.iOS
     {
         static void Main(string[] args)
         {
+#pragma warning disable CS0618
             UIApplication.Main(args, null, nameof(AppDelegate));
+#pragma warning restore CS0618
         }
     }
 }

--- a/Samples/Samples.iOS/Main.cs
+++ b/Samples/Samples.iOS/Main.cs
@@ -6,7 +6,9 @@ namespace Samples.iOS
     {
         static void Main(string[] args)
         {
+#pragma warning disable CS0618
             UIApplication.Main(args, null, nameof(AppDelegate));
+#pragma warning restore CS0618
         }
     }
 }

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.macos.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.macos.cs
@@ -27,7 +27,9 @@ namespace Xamarin.Essentials
 
             try
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 return NSString.FromHandle(computerNameHandle);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             finally
             {

--- a/Xamarin.Essentials/Platform/Platform.macos.cs
+++ b/Xamarin.Essentials/Platform/Platform.macos.cs
@@ -180,7 +180,9 @@ namespace Xamarin.Essentials
 
                 // we weren't able to work out what was happening, so try and guess
                 var typeHandle = IOPSGetProvidingPowerSourceType(infoHandle);
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (NSString.FromHandle(typeHandle) == kIOPMBatteryPowerKey)
+#pragma warning restore CS0618 // Type or member is obsolete
                     return BatteryState.Discharging;
 
                 return BatteryState.NotCharging;
@@ -245,7 +247,9 @@ namespace Xamarin.Essentials
             {
                 infoHandle = IOPSCopyPowerSourcesInfo();
                 var typeHandle = IOPSGetProvidingPowerSourceType(infoHandle);
+#pragma warning disable CS0618 // Type or member is obsolete
                 switch (NSString.FromHandle(typeHandle))
+#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     case kIOPMBatteryPowerKey:
                         return BatteryPowerSource.Battery;

--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
@@ -51,7 +51,10 @@ namespace Xamarin.Essentials
 
             void TryCancel()
             {
+#pragma warning disable 0618
+                // hWord is obsolete, but only just the latest release
                 ss.StopSpeaking(NSSpeechBoundary.hWord);
+#pragma warning restore 0618
                 tcs.TrySetResult(true);
             }
 


### PR DESCRIPTION
Several changes made in order to make CI successfull:
- changed `runs-on` in `ci.yml` to `windows-2019`
- added pragmas to disable deprecation errors